### PR TITLE
Probable crash if input boundary length is over 70 chars

### DIFF
--- a/multipartparser.c
+++ b/multipartparser.c
@@ -89,14 +89,16 @@ static const char header_field_chars[256] = {
     'x',    'y',    'z',    0,      '|',     0,     '~',    0
 };
 
-void multipartparser_init(multipartparser* parser, const char* boundary)
+int multipartparser_init(multipartparser* parser, const char* boundary)
 {
     memset(parser, 0, sizeof(*parser));
 
-    strncpy(parser->boundary, boundary, sizeof(parser->boundary));
+    strncpy(parser->boundary, boundary, sizeof(parser->boundary) - 1);
+    parser->boundary[sizeof(parser->boundary) - 1] = 0;
     parser->boundary_length = strlen(parser->boundary);
 
     parser->state = s_preamble;
+    return strlen(boundary) == strlen(parser->boundary);
 }
 
 void multipartparser_callbacks_init(multipartparser_callbacks* callbacks)

--- a/multipartparser.h
+++ b/multipartparser.h
@@ -16,7 +16,7 @@ typedef int (*multipart_data_cb) (multipartparser*, const char* data, size_t siz
 
 struct multipartparser {
     /** PRIVATE **/
-    char        boundary[70];
+    char        boundary[71];
     int         boundary_length;
     int         index;
     uint16_t    state;
@@ -36,7 +36,7 @@ struct multipartparser_callbacks {
     multipart_cb      on_body_end;
 };
 
-void multipartparser_init(multipartparser* parser, const char* boundary);
+int multipartparser_init(multipartparser* parser, const char* boundary);
 
 void multipartparser_callbacks_init(multipartparser_callbacks* callbacks);
 


### PR DESCRIPTION
The length storage for the boundary is 70 bytes, which is the max
boundary size given by the RFC 1341. If the input boundary is over
70 chars, the strncpy() no copy the final '\0' and the next strlen
cause a crash.

This patch controls the length and force final '\0'. the init function
return 0 if the init fail with a too long boundary. however, for
compatibility, the library remains initialized and could be used
without crash.